### PR TITLE
Change ftp_close to primarily do ftp's quit() and run close() only if the former excepts

### DIFF
--- a/FtpLibrary.py
+++ b/FtpLibrary.py
@@ -444,7 +444,10 @@ To run library remotely execute: python FtpLibrary.py <ipaddress> <portnumber>
         """
         thisConn = self.__getConnection(connId)
         try:
-            thisConn.close()
+            try:
+                thisConn.quit()
+            except Exception, e:
+                thisConn.close()
             self.__removeConnection(connId)
         except ftplib.all_errors as e:
             raise FtpLibraryError(str(e))


### PR DESCRIPTION
Once the FtpLibrary calls the disconnection of the session, the session isn't immediately quit. This leaves the session open and in certain cases the destination into a lingering state.

If a new FTP session is shortly after opened with the same ID, the connection can't be established.

While the disconnection with `thisConn.close()` is merciful, we have found that by using `thisConn.quit()` as the primary option is a more stable way to handle concatenated sessions. This means, that we should primarily `quit()` the session. While `quit()` doesn't always suit for each scenario, `close()` could be called if `quit()` isn't a working option through an exception. This needs to be done as an exception per `quit()`'s [documentation](https://docs.python.org/3.0/library/ftplib.html):

> but it may raise an exception if the server responds with an error to the QUIT command.

In either case, `__removeConnection` is always done.