### PR TITLE
Added TLS connection creation related keywords

### DIFF
--- a/FtpLibrary.py
+++ b/FtpLibrary.py
@@ -148,7 +148,7 @@ To run library remotely execute: python FtpLibrary.py <ipaddress> <portnumber>
                 port = int(port)
                 newFtp = ftplib.FTP()
                 outputMsg += newFtp.connect(host, port, timeout)
-                outputMsg += newFtp.login(user,password)
+                outputMsg += newFtp.login(user, password)
             except socket.error as se:
                 raise FtpLibraryError('Socket error exception occured.')
             except ftplib.all_errors as e:
@@ -159,9 +159,86 @@ To run library remotely execute: python FtpLibrary.py <ipaddress> <portnumber>
                 logger.info(outputMsg)
             self.__addNewConnection(newFtp, connId)
 
+    def ftp_tls_connect(self, host, user='anonymous', password='anonymous@', port=21, timeout=30, connId='default'):
+        """
+        Constructs FTP object with TLS support, opens a connection and login.
+        Call this function before any other (otherwise raises exception).
+        Returns server output.
+        Parameters:
+            - host - server host address
+            - user(optional) - FTP user name. If not given, 'anonymous' is used.
+            - password(optional) - FTP password. If not given, 'anonymous@' is used.
+            - port(optional) - TCP port. By default 21.
+            - timeout(optional) - timeout in seconds. By default 30.
+            - connId(optional) - connection identifier. By default equals 'default'
+        Examples:
+        | ftp tls connect | 192.168.1.10 | mylogin | mypassword |  |  |
+        | ftp tls connect | 192.168.1.10 |  |  |  |  |
+        | ftp tls connect | 192.168.1.10 | mylogin | mypassword | connId=secondConn |  |
+        | ftp tls connect | 192.168.1.10 | mylogin | mypassword | 29 | 20 |
+        | ftp tls connect | 192.168.1.10 | mylogin | mypassword | 29 |  |
+        | ftp tls connect | 192.168.1.10 | mylogin | mypassword | timeout=20 |  |
+        | ftp tls connect | 192.168.1.10 | port=29 | timeout=20 |  |  |
+        """
+        if connId in self.ftpList:
+            errMsg = "Connection with ID %s already exist. It should be deleted before this step." % connId
+            raise FtpLibraryError(errMsg)
+        else:
+            newFtps = None
+            outputMsg = ""
+            try:
+                timeout = int(timeout)
+                port = int(port)
+                newFtps = ftplib.FTP_TLS()
+                outputMsg += newFtps.connect(host, port, timeout)
+                outputMsg += newFtps.login(user, password)
+            except socket.error as se:
+                raise FtpLibraryError('Socket error exception occured.')
+            except ftplib.all_errors as e:
+                raise FtpLibraryError(str(e))
+            except Exception as e:
+                raise FtpLibraryError(str(e))
+            if self.printOutput:
+                logger.info(outputMsg)
+            self.__addNewConnection(newFtps, connId)
+
+    def clear_text_data_connection(self, connId='default'):
+        """
+        Switches to a clear text data connection.
+        Only usable with an FTP TLS connection. No effect if used with a regular ftp connection.
+        Parameters:
+        - connId(optional) - connection identifier. By default equals 'default'
+        """
+        outputMsg = ""
+        thisConn = self.__getConnection(connId)
+        try:
+            thisConn.prot_c()
+        except ftplib.all_errors as e:
+            raise FtpLibraryError(str(e))
+        if self.printOutput:
+            logger.info(outputMsg)
+        return outputMsg
+
+    def secure_data_connection(self, connId='default'):
+        """
+        Switches to a secure data connection.
+        Only usable with an FTP TLS connection. No effect if used with a regular ftp connection.
+        Parameters:
+        - connId(optional) - connection identifier. By default equals 'default'
+        """
+        outputMsg = ""
+        thisConn = self.__getConnection(connId)
+        try:
+            thisConn.prot_p()
+        except ftplib.all_errors as e:
+            raise FtpLibraryError(str(e))
+        if self.printOutput:
+            logger.info(outputMsg)
+        return outputMsg
+
     def get_welcome(self, connId='default'):
         """
-        Returns wlecome message of FTP server.
+        Returns welcome message of FTP server.
         Parameters:
         - connId(optional) - connection identifier. By default equals 'default'
         """

--- a/ftpLibraryExampleWithTls.txt
+++ b/ftpLibraryExampleWithTls.txt
@@ -1,0 +1,27 @@
+*** Settings ***
+Library    FtpLibrary
+
+*** Test Cases ***
+Login With Ftps
+    [Setup]    Ftp Tls Connect    ${ip}    ${username}    ${password}    connId=conn1
+    Secure Data Connection    connId=conn1
+    Validate An Active Ftp Connection
+    [Teardown]    Ftp Close    connId=conn1
+
+Incorrect Ftps Login Tests
+    [Tags]    FTP    No Video    MultiUser    Authentication
+    [Template]    Incorrect Ftps Login
+    ${EMPTY}       ${EMPTY}
+    ${username}    ${EMPTY}
+    ${EMPTY}       ${password}
+
+*** Keywords ***
+Validate An Active Ftp Connection
+    &{ftpConnections} =    Get All Ftp Connections
+    Log Many               &{ftpConnections}
+    Should Not Be Empty    ${ftpConnections}
+
+Incorrect Ftps Login
+    [Arguments]    ${user}    ${pw}
+    # 530 = Return code for an incorrect login
+    Run Keyword And Expect Error    *530*    Ftp Tls Connect    ${ip}    ${user}    ${pw}    port=${21}    timeout=${6}


### PR DESCRIPTION
This PR might be unfinished, but I'm unsure on what may be missing.

I've been using FtpLibrary, but had an app which required to establish a TLS supported connection. hence I had to add custom keyword (`ftp_tls_connect`) based on Python's ftplib's (https://docs.python.org/3.7/library/ftplib.html) `FTP_TLS` objects. While at it, I added a couple of other keywords for different connection options (`clear_text_data_connection`, `secure_data_connection`), which however I have not tested that much.

I noticed that when I had a TLS-supported connection created, some of the existing keywords (if I remember correctly, e.g. mkd and upload file) don't work. There might be something missing or it's part of the Python's ftplib's design, since the same occurred using native Python with the same functions.

Thus as there might be limitations when using a TLS-supported connection, I'm open for suggestions on the case of e.g. documentation.

TLS-supported connections themselves are a huge benefit for FtpLibrary as some applications might be totally inaccessible without its support.