### PR TITLE
Adding return to FTP Connect function

### DIFF
--- a/FtpLibrary.py
+++ b/FtpLibrary.py
@@ -180,6 +180,7 @@ To run library remotely execute: python FtpLibrary.py <ipaddress> <portnumber>
                 raise FtpLibraryError(str(e))
             if self.printOutput:
                 logger.info(outputMsg)
+            return outputMsg
 
     def clear_text_data_connection(self, connId='default'):
         """


### PR DESCRIPTION
Adding return outputMsg to FTP Connect function to be able to return server output message as a variable to Robot Framework not only log to Robot Framework. 
With server output we can evaluate something or anybody can verify that it connects right device with server output maybe. Documentation said that this keyword returns server output, it actually returns server output now as a variable :) 
Issue #22 is already opened, if you accept pull request I'll close that issue. 

Best Regards,
Mert